### PR TITLE
Add AccountId to a bucket placeholder option + fix S3

### DIFF
--- a/api-gateway/src/main/scala/com/virtuslab/zeitgeist/sbt/api_gateway/AwsApiGateway.scala
+++ b/api-gateway/src/main/scala/com/virtuslab/zeitgeist/sbt/api_gateway/AwsApiGateway.scala
@@ -1,22 +1,17 @@
 package com.virtuslab.zeitgeist.sbt.api_gateway
 
-import com.virtuslab.zeitgeist.sbt.{AwsCredentials, Region}
 import com.amazonaws.services.apigateway.{AmazonApiGateway, AmazonApiGatewayClientBuilder}
+import com.virtuslab.zeitgeist.sbt.{AwsClientSupport, Region}
 import sbt.Logger
 
-private[api_gateway] class AwsApiGateway(region: Region) {
+private[api_gateway] class AwsApiGateway(val region: Region) extends AwsClientSupport {
   lazy val apiClient: AmazonApiGateway = buildClient
 
   def getStageUrl(apiId: String, stageName: String)(implicit log: Logger): String = {
     s"https://${apiId}.execute-api.${region.value}.amazonaws.com/${stageName}/"
   }
 
-  private def buildClient = {
-    val clientBuilder = AmazonApiGatewayClientBuilder
-      .standard()
-      .withCredentials(AwsCredentials.provider)
-
-    clientBuilder.setRegion(region.value)
-    clientBuilder.build()
+  private def buildClient = setupClient {
+    AmazonApiGatewayClientBuilder.standard()
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Keys.publishTo
 import sbt.ScriptedPlugin.autoImport.scriptedBufferLog
 
-val projectVersion          = "0.1.0"
+val projectVersion          = "0.1.0-SNAPSHOT"
 val projectOrg              = "com.virtuslab.zeitgeist"
 val awsSdkVersion           = "1.11.458"
 
@@ -48,8 +48,9 @@ lazy val util = (project in file("util")).
     name := "sbt-util",
     sbtPlugin := true,
     libraryDependencies ++= Seq(
-      "com.amazonaws"  % "aws-java-sdk-iam"         % awsSdkVersion,
-      "com.amazonaws"  % "aws-java-sdk-s3"          % awsSdkVersion,
+      "com.amazonaws"  % "aws-java-sdk-iam"            % awsSdkVersion,
+      "com.amazonaws"  % "aws-java-sdk-sts"            % awsSdkVersion,
+      "com.amazonaws"  % "aws-java-sdk-s3"             % awsSdkVersion,
       "com.amazonaws"  % "aws-java-sdk-cloudformation" % awsSdkVersion
     )
   )

--- a/lambda/src/main/scala/com/virtuslab/zeitgeist/sbt/lambda/AWSLambdaClient.scala
+++ b/lambda/src/main/scala/com/virtuslab/zeitgeist/sbt/lambda/AWSLambdaClient.scala
@@ -13,9 +13,13 @@ private[sbt] case class LambdaParams(name: LambdaName, handlerName: HandlerName,
 
 private[sbt] case class S3Params(s3BucketId: S3BucketId, s3Key: S3Key)
 
-private[sbt] class AWSLambdaClient(region: Region) {
+private[sbt] class AWSLambdaClient(val region: Region) extends AwsClientSupport {
 
-  private lazy val lambdaClient = buildAwsClient
+  private lazy val lambdaClient = buildLambdaClient
+
+  protected def buildLambdaClient: AWSLambda = setupClient {
+    AWSLambdaClientBuilder.standard()
+  }
 
   def deployLambda(lambdaParams: LambdaParams, roleArn: RoleArn, s3Params: S3Params)(implicit log: Logger):
   Try[Either[CreateFunctionResult, UpdateFunctionCodeResult]] = {
@@ -129,14 +133,5 @@ private[sbt] class AWSLambdaClient(region: Region) {
     code.setS3Bucket(s3Params.s3BucketId.value)
     code.setS3Key(s3Params.s3Key.value)
     code
-  }
-
-  protected def buildAwsClient: AWSLambda = {
-    val clientBuilder = AWSLambdaClientBuilder
-      .standard()
-      .withCredentials(AwsCredentials.provider)
-
-    clientBuilder.setRegion(region.value)
-    clientBuilder.build()
   }
 }

--- a/lambda/src/main/scala/com/virtuslab/zeitgeist/sbt/lambda/AWSLambdaDeployer.scala
+++ b/lambda/src/main/scala/com/virtuslab/zeitgeist/sbt/lambda/AWSLambdaDeployer.scala
@@ -22,7 +22,7 @@ class AWSLambdaDeployer {
     val resolvedRegion = Region(region)
     val awsS3 = new AWSS3(resolvedRegion)
     val awsLambda = new AWSLambdaClient(resolvedRegion)
-    val awsIam = new AwsIam(resolvedRegion)
+    val awsIam = new AwsIAM(resolvedRegion)
     val resolvedLambdaName = LambdaName(lambdaName)
 
     val resolvedS3Key = s3KeyPrefix.getOrElse("") + jar.getName

--- a/lambda/src/main/scala/com/virtuslab/zeitgeist/sbt/lambda/AWSLambdaPlugin.scala
+++ b/lambda/src/main/scala/com/virtuslab/zeitgeist/sbt/lambda/AWSLambdaPlugin.scala
@@ -111,7 +111,8 @@ object AWSLambdaPlugin extends AutoPlugin {
     )(streams.value.log),
 
     lambdaName := sbt.Keys.name.value,
-    s3Bucket := sbt.Keys.organization.value + "." + lambdaName.value,
+
+    s3Bucket := sbt.Keys.organization.value,
 
     role := lambdaName.value,
 
@@ -140,9 +141,10 @@ object AWSLambdaPlugin extends AutoPlugin {
 
   private def resolveBucketName = Def.task[S3BucketId] {
     val resolvedRegion = Region(region.value)
-    val awsIam = new AwsIam(resolvedRegion)
+    val awsIAM = new AwsIAM(resolvedRegion)
+    val awsSTS = new AwsSTS(resolvedRegion)
 
-    val bucketNameResolver = new S3BucketResolver(awsIam)
+    val bucketNameResolver = new S3BucketResolver(awsIAM, awsSTS)
     val bucketId = S3BucketId(s3Bucket.value)
     bucketNameResolver.resolveBucketName(bucketId)(streams.value.log).get
   }

--- a/lambda/src/main/scala/com/virtuslab/zeitgeist/sbt/lambda/S3BucketResolver.scala
+++ b/lambda/src/main/scala/com/virtuslab/zeitgeist/sbt/lambda/S3BucketResolver.scala
@@ -2,20 +2,21 @@ package com.virtuslab.zeitgeist.sbt.lambda
 
 import java.net.InetAddress
 
-import com.virtuslab.zeitgeist.sbt.{AwsIam, AwsUser, S3BucketId}
+import com.virtuslab.zeitgeist.sbt.{AwsAccount, AwsIAM, AwsSTS, AwsUser, S3BucketId}
 import sbt.util.Logger
-
 import scala.util.{Failure, Success, Try}
 
 import S3BucketResolver._
+
 case class UserNameNotAvailable() extends Exception(
   s"Username not returned by AWS SDK. Consider using: ${fullPlaceHolder(PlaceHolderUserId)} instead of" +
-  s"${fullPlaceHolder(PlaceHolderUserName)}"
+    s"${fullPlaceHolder(PlaceHolderUserName)}"
 )
 
 object S3BucketResolver {
   private[lambda] val PlaceHolderUserName = "username"
   private[lambda] val PlaceHolderUserId = "userid"
+  private[lambda] val PlaceHolderAccountId = "accountid"
   private[lambda] val PlaceHolderHostname = "hostname"
 
   private[lambda] def fullPlaceHolder(id: String) = s"{${id}}"
@@ -24,31 +25,34 @@ object S3BucketResolver {
 /**
   * Resolves placeholders within bucket name.
   */
-class S3BucketResolver(awsIam: AwsIam) {
+class S3BucketResolver(awsIam: AwsIAM, awsSTS: AwsSTS) {
   def resolveBucketName(bucketId: S3BucketId)(implicit log: Logger): Try[S3BucketId] = {
     val bucketName = bucketId.value
 
-    val tryUser = if(containsAwsPlaceholder(bucketName)) {
-      awsIam.getCurrentAwsUser.flatMap { user =>
-        if(containsUserName(bucketName) && user.userName.isEmpty) {
-          Failure(new UserNameNotAvailable)
-        } else {
-          Success(user)
+    val tryUser =
+      if (containsAwsPlaceholder(bucketName)) {
+        awsIam.getCurrentAwsUser.flatMap { user =>
+          if (containsUserName(bucketName) && user.userName.isEmpty) {
+            Failure(new UserNameNotAvailable)
+          } else {
+            Success(user)
+          }
         }
+      } else {
+        Success(AwsUser(userId = "", userName = Option("")))
       }
-    } else {
-      Success(AwsUser(userId = "", userName = Option("")))
-    }
 
     val localhost = InetAddress.getLocalHost.getHostName
 
     for {
       AwsUser(userId, userName) <- tryUser
+      AwsAccount(accountId, _) <- awsSTS.getAccount()
     } yield {
       S3BucketId(
         bucketName
           .replaceAll(s"(?i)\\${fullPlaceHolder(PlaceHolderUserId)}", userId)
           .replaceAll(s"(?i)\\${fullPlaceHolder(PlaceHolderUserName)}", userName.getOrElse(""))
+          .replaceAll(s"(?i)\\${fullPlaceHolder(PlaceHolderAccountId)}", accountId)
           .replaceAll(s"(?i)\\${fullPlaceHolder(PlaceHolderHostname)}", localhost)
           .toLowerCase
       )
@@ -61,6 +65,10 @@ class S3BucketResolver(awsIam: AwsIam) {
 
   private def containsUserId(bucketName: String) = {
     bucketName.toLowerCase.contains(fullPlaceHolder(PlaceHolderUserId))
+  }
+
+  private def containsAccountId(bucketName: String) = {
+    bucketName.toLowerCase.contains(fullPlaceHolder(PlaceHolderAccountId))
   }
 
   private def containsUserName(bucketName: String) = {

--- a/lambda/src/test/scala/com/virtuslab/zeitgeist/sbt/lambda/AwsLambdaSpec.scala
+++ b/lambda/src/test/scala/com/virtuslab/zeitgeist/sbt/lambda/AwsLambdaSpec.scala
@@ -20,7 +20,7 @@ class AwsLambdaSpec extends WordSpec with MustMatchers with MockFactory with Sbt
 
 
       val awsLambdaClient = new AWSLambdaClient(Region("region")) {
-        override protected def buildAwsClient = {
+        override protected def buildLambdaClient: AWSLambda = {
           val m = stub[AWSLambda]
 
           val getRequest = new GetFunctionRequest

--- a/util/src/main/scala/com/virtuslab/zeitgeist/sbt/AwsClientSupport.scala
+++ b/util/src/main/scala/com/virtuslab/zeitgeist/sbt/AwsClientSupport.scala
@@ -1,0 +1,14 @@
+package com.virtuslab.zeitgeist.sbt
+
+import com.amazonaws.client.builder.AwsClientBuilder
+
+trait AwsClientSupport {
+  val region: Region
+
+  protected def setupClient[C, T <: AwsClientBuilder[_ <: AnyRef, C]](builder: AwsClientBuilder[T, C]): C = {
+    builder.setCredentials(AwsCredentials.provider)
+    builder.setRegion(region.value)
+    builder.build()
+  }
+
+}

--- a/util/src/main/scala/com/virtuslab/zeitgeist/sbt/AwsIAM.scala
+++ b/util/src/main/scala/com/virtuslab/zeitgeist/sbt/AwsIAM.scala
@@ -8,9 +8,13 @@ import scala.util.{Failure, Try}
 
 case class AwsUser(userId: String, userName: Option[String])
 
-private[sbt] class AwsIam(region: Region) {
+private[sbt] class AwsIAM(val region: Region) extends AwsClientSupport {
 
-  lazy val iamClient: AmazonIdentityManagement = buildIamClient
+  lazy val iamClient: AmazonIdentityManagement = buildIAMClient
+
+  protected def buildIAMClient: AmazonIdentityManagement = setupClient {
+    AmazonIdentityManagementClientBuilder.standard()
+  }
 
   def getOrCreateRole(roleName: RoleName, autoCreate: Boolean)
                      (implicit log: Logger): Try[Role] = {
@@ -28,15 +32,6 @@ private[sbt] class AwsIam(region: Region) {
       case e: Throwable =>
         Failure(e)
     }
-  }
-
-  protected def buildIamClient: AmazonIdentityManagement = {
-    val builder = AmazonIdentityManagementClientBuilder
-      .standard()
-      .withCredentials(AwsCredentials.provider)
-
-    builder.setRegion(region.value)
-    builder.build()
   }
 
   private def getRole(roleName: RoleName)(implicit log: Logger): Try[Role] = Try {

--- a/util/src/main/scala/com/virtuslab/zeitgeist/sbt/AwsSTS.scala
+++ b/util/src/main/scala/com/virtuslab/zeitgeist/sbt/AwsSTS.scala
@@ -1,0 +1,26 @@
+package com.virtuslab.zeitgeist.sbt
+
+import scala.util.Try
+
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
+import com.amazonaws.services.securitytoken.{AWSSecurityTokenService, AWSSecurityTokenServiceClientBuilder}
+
+case class AwsAccount(id: String, arn: String)
+
+private[sbt] class AwsSTS(val region: Region) extends AwsClientSupport {
+  lazy val stsClient: AWSSecurityTokenService = buildSTSClient
+
+  protected def buildSTSClient: AWSSecurityTokenService = setupClient {
+    AWSSecurityTokenServiceClientBuilder.standard()
+  }
+
+  def getAccount(): Try[AwsAccount] = Try {
+    val rq = new GetCallerIdentityRequest()
+    val rs = stsClient.getCallerIdentity(rq)
+
+    AwsAccount(
+      id = rs.getAccount,
+      arn = rs.getArn
+    )
+  }
+}

--- a/util/src/main/scala/com/virtuslab/zeitgeist/sbt/DomainModels.scala
+++ b/util/src/main/scala/com/virtuslab/zeitgeist/sbt/DomainModels.scala
@@ -1,7 +1,5 @@
 package com.virtuslab.zeitgeist.sbt
 
-import com.amazonaws.services.cloudformation.model.Output
-
 case class APIId(value: String) extends AnyVal
 case class Region(value: String) extends AnyVal
 case class S3BucketId(value: String) extends AnyVal

--- a/util/src/test/scala/com/virtuslab/zeitgeist/sbt/AwsIAMSpec.scala
+++ b/util/src/test/scala/com/virtuslab/zeitgeist/sbt/AwsIAMSpec.scala
@@ -7,29 +7,25 @@ import org.scalatest.{MustMatchers, WordSpec}
 
 import scala.util.Success
 
-class AwsIamSpec extends WordSpec with MustMatchers with MockFactory with SbtTest {
+class AwsIAMSpec extends WordSpec with MustMatchers with MockFactory with SbtTest {
 
   "Creating new role" should {
     "must fail if policy already exists" in {
       val roleName = "myRoleName"
       val roleArn = "roleArn"
 
-      val awsIamClient = new AwsIam(Region("region")) {
-        override protected def buildIamClient: AmazonIdentityManagement = {
+      val awsIamClient = new AwsIAM(Region("region")) {
+        override protected def buildIAMClient: AmazonIdentityManagement = {
           val m = mock[AmazonIdentityManagement]
-          val awsRole = new AwsRole
-          awsRole.setRoleName(roleName)
-          awsRole.setArn(roleArn)
-
-          val result = new GetRoleResult
-          result.setRole(awsRole)
+          val awsRole = new AwsRole().withRoleName(roleName).withArn(roleArn)
+          val result = new GetRoleResult().withRole(awsRole)
 
           (m.getRole _).expects(*).returning(result)
           m
         }
       }
 
-      val result = awsIamClient.getOrCreateRole(RoleName(roleName), true)
+      val result = awsIamClient.getOrCreateRole(RoleName(roleName), autoCreate = true)
       result must be(Success(
         Role(RoleName(roleName), RoleArn(roleArn)))
       )

--- a/util/src/test/scala/com/virtuslab/zeitgeist/sbt/AwsSTSSpec.scala
+++ b/util/src/test/scala/com/virtuslab/zeitgeist/sbt/AwsSTSSpec.scala
@@ -1,0 +1,50 @@
+package com.virtuslab.zeitgeist.sbt
+
+import scala.util.{Failure, Success}
+
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService
+import com.amazonaws.services.securitytoken.model.{AWSSecurityTokenServiceException, GetCallerIdentityResult}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{MustMatchers, WordSpec}
+
+class AwsSTSSpec extends WordSpec with MustMatchers with MockFactory with SbtTest {
+
+  "Getting account" should {
+    "read caller account details" in {
+      val accountId = "1234-abcd"
+      val accountArn = "arn:aws:iam::1234-abcd:user/Bob"
+
+      val awsStsClient = new AwsSTS(Region("region")) {
+        override protected def buildSTSClient: AWSSecurityTokenService = {
+          val client = stub[AWSSecurityTokenService]
+          val result = new GetCallerIdentityResult()
+            .withAccount(accountId)
+            .withArn(accountArn)
+            .withUserId("userId")
+
+          (client.getCallerIdentity _).when(*).returning(result)
+
+          client
+        }
+      }
+
+      awsStsClient.getAccount() mustBe Success(
+        AwsAccount(accountId, accountArn)
+      )
+    }
+
+    "fail if AWS client throws exception" in {
+      val exception = new AWSSecurityTokenServiceException("n/a")
+
+      val awsStsClient = new AwsSTS(Region("region")) {
+        override protected def buildSTSClient: AWSSecurityTokenService = {
+          val client = stub[AWSSecurityTokenService]
+          (client.getCallerIdentity _).when(*).throwing(exception)
+          client
+        }
+      }
+
+      awsStsClient.getAccount() mustBe Failure(exception)
+    }
+  }
+}

--- a/util/src/test/scala/com/virtuslab/zeitgeist/sbt/SbtTest.scala
+++ b/util/src/test/scala/com/virtuslab/zeitgeist/sbt/SbtTest.scala
@@ -3,7 +3,7 @@ package com.virtuslab.zeitgeist.sbt
 import sbt.{Level, Logger}
 
 trait SbtTest {
-  implicit val logger = new Logger {
+  implicit val logger: Logger = new Logger {
     override def log(level: Level.Value, message: => String): Unit = println(s"${level.toString.toUpperCase}:\t${message}")
     override def trace(t: => Throwable): Unit = t.printStackTrace()
     override def success(message: => String): Unit = println(message)


### PR DESCRIPTION
1. Introduced new placeholder for S3 bucket (`accountId`)
2. Fixed couple `Try`s that were eating errors
3. Code cleanups (it may be a bit messy, let me know if you want me to organize it into commits).